### PR TITLE
Update the parsing code to ignore empty album titles

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const { log } = util;
 const { SPOTIFY_USERNAME } = process.env;
 
 async function doSpotifyParts(options) {
-  const { searchTerms } = options;
+  const { albumNames } = options;
 
   if (options.refreshToken) {
     process.stdout.write('Using Refresh Token to request a new Spotify Access Token... ');
@@ -28,7 +28,7 @@ async function doSpotifyParts(options) {
   }
   const playlistId = options.playlistId || await spotify.createPlaylist(options.playlistName);
 
-  const albumTracks = await spotify.searchManyAlbums(searchTerms);
+  const albumTracks = await spotify.searchManyAlbums(albumNames);
   const totalAlbums = albumTracks.length;
   const foundAlbums = albumTracks.filter(tracks => tracks.length).length;
   const tracks = util.flatten(albumTracks);
@@ -82,8 +82,12 @@ async function doParseParts(options) {
     return process.exit(1);
   }
   log(chalk.green(`Found ${searchTerms.length} search terms:`));
+  let albumNames = [];
   searchTerms.forEach((searchTerm) => {
-    log(`  -  ${chalk.blue(searchTerm)}`);
+    if(searchTerm) {
+      log(`  -  ${chalk.blue(searchTerm)}`);
+      albumNames.push(searchTerm);
+    }
   });
 
   // ask user to confirm that search terms look right
@@ -98,7 +102,7 @@ async function doParseParts(options) {
 
   // add searchTerms to the options object and pass it on
   return Object.assign({}, options, {
-    searchTerms,
+    albumNames,
   });
 }
 


### PR DESCRIPTION
Configuration with issues/test case:

```
Hey, it's Scrapify.

PAGE_URL is http://www.npr.org/2017/07/24/538307314/turning-the-tables-150-greatest-albums-made-by-women-page-15
QUERY_SELECTOR is h3.edTag em
PLAYLIST_ID is ...
REFRESH_TOKEN is ...

Fetching your URL... Success!
Scraping for search terms...
Found 12 search terms:
  -  Tapestry
  -  Back To Black
  -  Pearl
  -
  -  Horses
  -  Lemonade
  -
  -  Supa Dupa Fly
  -  I Never Loved a Man The Way I Love You
  -  I Put A Spell on You
  -  The Miseducation of Lauryn Hill
  -  Blue
Look OK? Hit enter to continue...
```


With the fix:

```
Hey, it's Scrapify.

PAGE_URL is http://www.npr.org/2017/07/24/538307314/turning-the-tables-150-greatest-albums-made-by-women-page-15
QUERY_SELECTOR is h3.edTag em
PLAYLIST_ID is ...
REFRESH_TOKEN is ...

Fetching your URL... Success!
Scraping for search terms...
Found 12 search terms:
  -  Tapestry
  -  Back To Black
  -  Pearl
  -  Horses
  -  Lemonade
  -  Supa Dupa Fly
  -  I Never Loved a Man The Way I Love You
  -  I Put A Spell on You
  -  The Miseducation of Lauryn Hill
  -  Blue
Look OK? Hit enter to continue...
```